### PR TITLE
fix: wrong way to write grub file

### DIFF
--- a/src/variables.sh
+++ b/src/variables.sh
@@ -3,7 +3,7 @@
 # VARIABLES (general used like username, borgbackup location etc.)
 # NOTE: Change these variables as needed.
 USER="developer"
-SESSION="Qtile"
+SESSION="qtile"
 hostname_desktop="fedora"
 hostname_laptop="fedora-laptop"
 boot_file="/etc/default/grub"


### PR DESCRIPTION
I was using echo to write grub file but it was a fatal flaw because echo overwriting the file by deleting other lines. So, I was changed that to grep to be able to keep other lines.

This pull request includes changes to improve the setup process in `setup.sh` and to correct a session name in `src/variables.sh`. The most important changes include modifying the GRUB timeout configuration, updating LightDM settings, and correcting the session name.

Improvements to setup process:

* [`setup.sh`](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L242-R244): Changed the method for setting the GRUB timeout to 0 to ensure it only updates if not already set, preserving other lines in the configuration.
* [`setup.sh`](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R258-R275): Updated LightDM configuration to include additional autologin settings and improved comments for clarity.

Correction of session name:

* [`src/variables.sh`](diffhunk://#diff-c0bb8c1e9208b9fcdaa1e47c280dc8e0785ee696135a5931a9a71706cfe2227eL6-R6): Corrected the session name from "Qtile" to "qtile" to match the expected case.