### PR TITLE
fix: variable.sh notify and add github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: autorelease
+
+on:
+  push:
+    branches: [ master, main ]  # support both master and main branch names
+    tags:
+      - 'v*'  # this will trigger on any tag that starts with 'v'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3  # updated to newer version
+        with:
+          fetch-depth: 0  # this ensures all tags and history are available
+      
+      - name: create release
+        uses: cupoftea696/gh-action-auto-release@v1.0.2  # updated to newer version
+        with:
+          title: "release: $version"
+          tag: "v$semver"
+          draft: false
+          regex: "/^release: v?#{semver}$/i"  # more flexible regex pattern
+          prereleaseregex: "/^release: v?#{semver}-.*$/i"
+        env:
+          github_token: ${{ secrets.github_token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## v0.2.1-alpha
+### Changed
+  - Add github action for release
+  -
+  
+## v0.2.0-alpha
+### Changed
+  - fix: specific host options by @Cyber-Syntax in https://github.com/Cyber-Syntax/fedora-setup/pull/3
+  - Add unit tests, improve logging, and enhance backup configurations by @Cyber-Syntax in https://github.com/Cyber-Syntax/fedora-setup/pull/4
+## v0.1.0-alpha
+### What's Changed
+  - Feat/laptop desktop by @Cyber-Syntax in https://github.com/Cyber-Syntax/fedora-setup/pull/1
+  - fix: wrong way to write grub file by @Cyber-Syntax in https://github.com/Cyber-Syntax/fedora-setup/pull/2
+  - Initial setup script for Fedora

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## v0.2.1-alpha
 ### Changed
   - Add github action for release
-  -
+  - refactor: variable.sh notify
   
 ## v0.2.0-alpha
 ### Changed

--- a/setup.sh
+++ b/setup.sh
@@ -17,19 +17,14 @@ source src/apps.sh
 source src/desktop.sh
 source src/laptop.sh
 
-# Variable notifying the user that the script is running.
-if ! id "$USER" &>/dev/null; then
-  log_warn "You forget to change variables according to your needs. Go src/variables.sh and change according to your needs."
-  # Check if user forgot to change the VARIABLES.
-  if [ -n "$SUDO_USER" ]; then
-    whoami="$SUDO_USER"
-  else
-    whoami=$(whoami)
-  fi
-
-  log_warn "Script USER variable is: $USER but your username: $whoami."
-  log_warn "Please change the USER variable and other variables according to your system configuration."
-
+echo "=================================================="
+echo "important: this script uses configuration values from src/variables.sh"
+echo "please ensure you've reviewed and adjusted these values for your system."
+echo "=================================================="
+#TODO: better way to check and notify user to prevent variable errors.
+read -p "Have you reviewed src/variables.sh? (y/n): " user_confirmed
+if [[ "${user_confirmed,,}" != "y" ]]; then
+  log_warn "Please review src/variables.sh before running this script."
   exit 1
 fi
 
@@ -428,8 +423,6 @@ main() {
     if [[ "$system_type" == "laptop" ]]; then
       log_info "Executing laptop-specific functions..."
       laptop_hostname_change
-      #TEST: Currently on laptop but can be used on globally when desktop switch lightdm
-      nopasswdlogin_group
       tlp_setup
       thinkfan_setup
       touchpad_setup
@@ -450,6 +443,7 @@ main() {
     setup_files "$system_type"
     switch_ufw_setup
 
+    nopasswdlogin_group
     # services
     syncthing_setup
     trash_cli_setup

--- a/src/packages.sh
+++ b/src/packages.sh
@@ -94,4 +94,5 @@ FLATPAK_PACKAGES=(
   # Proprietary softwares
   md.obsidian.Obsidian
   com.spotify.Client
+  com.zed.Zed # Zed editor
 )

--- a/src/variables.sh
+++ b/src/variables.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
+
+
+USER=$(whoami)  # automatically detect current user
 # User-specific variables
-# WARN: Change these variables as needed.
-USER="developer"
+# WARN: Change these variables as needed
+# WARNING: Comment out the line below if you want to use the detected user.
 SESSION="qtile"
 LAPTOP_IP="192.168.1.54"
 


### PR DESCRIPTION
This pull request includes several changes aimed at improving the automation, documentation, and user experience of the setup script. The most important changes include adding a GitHub action for automatic releases, updating the changelog, refactoring user notifications in the setup script, and adding a new package to the list of Flatpak installations.

Automation and CI/CD:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R1-R27): Added a new GitHub action for automatic releases on push to `master` or `main` branches, and on tags starting with 'v'. Updated the action versions and improved the regex pattern for release tags.

Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R17): Created a changelog file to document all notable changes to the project, including the addition of the GitHub action for releases and various other updates.

User notifications and script improvements:

* [`setup.sh`](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17L20-R27): Refactored the notification to users about reviewing `src/variables.sh` by adding a confirmation prompt and improving the clarity of the message.
* [`setup.sh`](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R446): Moved the `nopasswdlogin_group` function call to a more appropriate location within the `main` function to ensure it runs correctly.

Package updates:

* [`src/packages.sh`](diffhunk://#diff-18349c96c5af242f110ede118d027030197213bb6348de324efbee19e1c8565bR97): Added the `com.zed.Zed` editor to the list of Flatpak packages to be installed.

User-specific variables:

* [`src/variables.sh`](diffhunk://#diff-c0bb8c1e9208b9fcdaa1e47c280dc8e0785ee696135a5931a9a71706cfe2227eR3-R8): Updated the `USER` variable to automatically detect the current user by default, with an option to override it.